### PR TITLE
Add gem version conditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ You may want to use these bad boys next to:
 
 For simplicity, the date comparison uses machine-local time (not e.g. the Rails configured time zone).
 
+Alternatively, the `FIXME()` method can also raise if a certain version of a component is installed:
+
+```
+FIXME "rspec >= 2.11: switch to expect syntax"
+```
+
+This will raise an exception once you have rspec >= 2.11 in your bundle. For
+now only the ">=" constraint is supported.
+
+Note that this form assumes you use bundler, and it won't raise if the specified
+gem is not part of the bundle.
+
 Protip: make sure it's clear from the exception or from a separate comment just what should be done – sometimes not even the person who wrote the quickfix will remember what you're meant to change.
 
 ### Environment awareness

--- a/spec/fixme_spec.rb
+++ b/spec/fixme_spec.rb
@@ -41,6 +41,24 @@ describe Fixme, "#FIXME" do
     }.to raise_error("Fix by 2013-12-31: Remove this: and this.")
   end
 
+  it "accepts a version constraint instead of a date as a condition" do
+    expect {
+      FIXME "rspec >= 0.1: don't forget to do this."
+    }.to raise_error("Fix when rspec >= 0.1: don't forget to do this.")
+  end
+
+  it "doesn't explode if a version constraint is not validated" do
+    expect {
+      FIXME "rspec >= 999.9.3: don't forget to do this."
+    }.not_to raise_error
+  end
+
+  it "doesn't explode if gem is not part of the bundle" do
+    expect {
+      FIXME "not-installed-gem >= 0.0: don't forget to do this."
+    }.not_to raise_error
+  end
+
   it "is available everywhere" do
     expect {
       "some random object".instance_eval do


### PR DESCRIPTION
I found your gem via [the changelog weekly newsletter](https://changelog.com/weekly/) and I love the concept. But I immediately thought that it would be cool to be able to make conditionals not only about a fixed date, but also about gem versions in your bundle: I often find myself writing TODO comments to not forget to do something when I upgrade to rails/devise/whatever next version, and half of the time I forget to do so.

Do you think it would be a feature you'd want in your gem? I open a pull request directly with a first draft achieving this, but don't hesitate to tell me if 1/ you don't want such a feature or 2/ the code doesn't satisfy you. I can also improve the tests or avoid "method_missing" if you tell me.

In any case, thanks for a super useful little helper, I'll use it in all my projects I think :-)