### PR TITLE
CI: Drop Ruby 2.6. EOL.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,9 @@ jobs:
           - 3.1
           - "3.0"
           - 2.7
-          - 2.6
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This PR drops a Ruby from the build matrix.