### PR TITLE
CI: Add Ruby 3.3, 3.4, drop EOL Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - 3.4
+          - 3.3
           - 3.2
           - 3.1
-          - "3.0"
-          - 2.7
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR updates the build matrix.